### PR TITLE
D15: Add observability-gateway repo-local CI baseline

### DIFF
--- a/.github/workflows/observability-local-ci.yml
+++ b/.github/workflows/observability-local-ci.yml
@@ -1,0 +1,53 @@
+name: Observability Gateway Local CI
+
+on:
+  pull_request:
+    paths:
+      - "config/**"
+      - "contracts/**"
+      - "scripts/**"
+      - "README.md"
+      - ".github/workflows/observability-local-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "config/**"
+      - "contracts/**"
+      - "scripts/**"
+      - "README.md"
+      - ".github/workflows/observability-local-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  observability-local-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run ingest smoke scenarios
+        run: |
+          mkdir -p /tmp/o11y/ingest
+          python3 scripts/langfuse_ingest_smoke.py \
+            --scenario normal \
+            --run-id "ci-${{ github.run_id }}-o11y" \
+            --output-dir /tmp/o11y/ingest
+          python3 scripts/langfuse_ingest_smoke.py \
+            --scenario delay_and_replay \
+            --run-id "ci-${{ github.run_id }}-o11y" \
+            --output-dir /tmp/o11y/ingest
+
+      - name: Validate contract pin
+        run: |
+          mkdir -p /tmp/o11y
+          python3 scripts/validate_contract_pin.py \
+            --output /tmp/o11y/contract-pin-report.json
+
+      - name: Seeded failure guard (deterministic replay + invalid pin)
+        run: bash scripts/test_observability_guardrails.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Local-first observability gateway baseline for UAP runtime.
 ```bash
 python3 scripts/langfuse_ingest_smoke.py --scenario normal
 python3 scripts/langfuse_ingest_smoke.py --scenario delay_and_replay
+python3 scripts/validate_contract_pin.py
+bash scripts/test_observability_guardrails.sh
 ```
 
 ## Local LangFuse Launcher and Replay/Backfill Drill
@@ -33,3 +35,26 @@ Artifacts:
 - `artifacts/ingest/<run_id>-normal.json`
 - `artifacts/ingest/<run_id>-delay_and_replay.json`
 - `artifacts/launcher/<run_id>.json`
+
+## Local CI Baseline
+- workflow: `.github/workflows/observability-local-ci.yml`
+- checks:
+  - ingest smoke (`normal`, `delay_and_replay`)
+  - deterministic replay/dedupe assertions
+  - contract pin validation (`scripts/validate_contract_pin.py`)
+  - seeded failure guard (`scripts/test_observability_guardrails.sh`)
+
+### Contract Pin Remediation
+When contract pin validation fails:
+1. Open `config/contract-pin.json`.
+2. Ensure:
+   - `source_repo == rather-not-work-on/platform-contracts`
+   - `consumer_repo == rather-not-work-on/platform-observability-gateway`
+   - `contract_bundle_version` format is `YYYY.MM.DD`
+   - `pinned_contracts` contains `c5-observability-event`
+3. Re-run:
+
+```bash
+python3 scripts/validate_contract_pin.py
+bash scripts/test_observability_guardrails.sh
+```

--- a/scripts/langfuse_ingest_smoke.py
+++ b/scripts/langfuse_ingest_smoke.py
@@ -118,6 +118,11 @@ def main():
     parser = argparse.ArgumentParser(description="LangFuse ingest smoke scenarios")
     parser.add_argument("--scenario", choices=["normal", "delay_and_replay"], default="normal")
     parser.add_argument("--run-id", default=None)
+    parser.add_argument(
+        "--output-dir",
+        default="artifacts/ingest",
+        help="directory where ingest smoke report is written",
+    )
     args = parser.parse_args()
 
     run_id = args.run_id or f"o11y-smoke-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
@@ -153,7 +158,7 @@ def main():
         "events": unique_events,
     }
 
-    out = Path(f"artifacts/ingest/{run_id}-{args.scenario}.json")
+    out = Path(args.output_dir) / f"{run_id}-{args.scenario}.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
 

--- a/scripts/test_observability_guardrails.sh
+++ b/scripts/test_observability_guardrails.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RUN_ID="o11y-ci-guard"
+OUT_DIR="$TMP_DIR/ingest"
+mkdir -p "$OUT_DIR"
+
+python3 "$ROOT_DIR/scripts/langfuse_ingest_smoke.py" \
+  --scenario normal \
+  --run-id "$RUN_ID" \
+  --output-dir "$OUT_DIR"
+
+python3 "$ROOT_DIR/scripts/langfuse_ingest_smoke.py" \
+  --scenario delay_and_replay \
+  --run-id "$RUN_ID" \
+  --output-dir "$OUT_DIR"
+
+NORMAL_REPORT="$OUT_DIR/$RUN_ID-normal.json"
+REPLAY_REPORT="$OUT_DIR/$RUN_ID-delay_and_replay.json"
+
+python3 - "$NORMAL_REPORT" "$REPLAY_REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+normal = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+replay = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+if normal.get("verdict") != "pass":
+    raise SystemExit("normal scenario must pass")
+if replay.get("verdict") != "pass":
+    raise SystemExit("delay_and_replay scenario must pass")
+
+if normal["dedupe"]["output_count"] != 2:
+    raise SystemExit("normal output_count must be 2")
+if replay["dedupe"]["output_count"] != 3:
+    raise SystemExit("delay_and_replay output_count must be 3")
+
+duplicates = replay["dedupe"]["duplicate_event_ids"]
+if duplicates != ["evt-002"]:
+    raise SystemExit(f"unexpected replay duplicates: {duplicates}")
+PY
+
+python3 "$ROOT_DIR/scripts/validate_contract_pin.py" \
+  --output "$TMP_DIR/contract-pin-report.json"
+
+INVALID_PIN="$TMP_DIR/contract-pin.invalid.json"
+cat > "$INVALID_PIN" <<'JSON'
+{
+  "source_repo": "rather-not-work-on/platform-contracts",
+  "contract_bundle_version": "2026.02.28",
+  "pinned_contracts": [],
+  "consumer_repo": "rather-not-work-on/platform-observability-gateway"
+}
+JSON
+
+if python3 "$ROOT_DIR/scripts/validate_contract_pin.py" \
+  --pin "$INVALID_PIN" \
+  --output "$TMP_DIR/contract-pin-invalid-report.json"; then
+  echo "[FAIL] invalid contract pin unexpectedly passed"
+  exit 1
+fi
+
+echo "observability guardrails regression passed"

--- a/scripts/validate_contract_pin.py
+++ b/scripts/validate_contract_pin.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+
+
+BUNDLE_VERSION_PATTERN = re.compile(r"^\d{4}\.\d{2}\.\d{2}$")
+CONTRACT_ID_PATTERN = re.compile(r"^c[1-8]-[a-z0-9-]+$")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def validate_pin(pin: dict, required_contracts):
+    errors = []
+    warnings = []
+
+    if pin.get("source_repo") != "rather-not-work-on/platform-contracts":
+        errors.append(
+            "source_repo must be 'rather-not-work-on/platform-contracts' "
+            "(see README.md#contract-pin-remediation)"
+        )
+    if pin.get("consumer_repo") != "rather-not-work-on/platform-observability-gateway":
+        errors.append(
+            "consumer_repo must be 'rather-not-work-on/platform-observability-gateway' "
+            "(see README.md#contract-pin-remediation)"
+        )
+
+    version = pin.get("contract_bundle_version")
+    if not isinstance(version, str) or not BUNDLE_VERSION_PATTERN.match(version):
+        errors.append(
+            "contract_bundle_version must match YYYY.MM.DD "
+            "(see README.md#contract-pin-remediation)"
+        )
+
+    pinned = pin.get("pinned_contracts")
+    if not isinstance(pinned, list) or not pinned:
+        errors.append(
+            "pinned_contracts must be a non-empty list "
+            "(see README.md#contract-pin-remediation)"
+        )
+        pinned = []
+
+    duplicates = sorted({c for c in pinned if pinned.count(c) > 1})
+    if duplicates:
+        errors.append(
+            f"pinned_contracts must be unique; duplicates={duplicates} "
+            "(see README.md#contract-pin-remediation)"
+        )
+
+    invalid_ids = [c for c in pinned if not isinstance(c, str) or not CONTRACT_ID_PATTERN.match(c)]
+    if invalid_ids:
+        errors.append(
+            f"invalid contract ids={invalid_ids}; expected c<1-8>-<name> "
+            "(see README.md#contract-pin-remediation)"
+        )
+
+    missing_required = sorted(set(required_contracts) - set(pinned))
+    if missing_required:
+        errors.append(
+            f"missing required contracts={missing_required} "
+            "(see README.md#contract-pin-remediation)"
+        )
+
+    extras = sorted(set(pinned) - set(required_contracts))
+    if extras:
+        warnings.append(f"additional pinned contracts detected={extras}")
+
+    return errors, warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate observability-gateway contract pin policy")
+    parser.add_argument("--pin", default="config/contract-pin.json")
+    parser.add_argument("--output", default="artifacts/ingest/contract-pin-report.json")
+    parser.add_argument("--required-contracts", default="c5-observability-event")
+    args = parser.parse_args()
+
+    required_contracts = [c.strip() for c in args.required_contracts.split(",") if c.strip()]
+    pin_path = Path(args.pin)
+    try:
+        pin = load_json(pin_path)
+    except json.JSONDecodeError as exc:
+        report = {
+            "generated_at_utc": now_utc(),
+            "verdict": "fail",
+            "pin_path": args.pin,
+            "error_count": 1,
+            "warning_count": 0,
+            "errors": [f"invalid JSON: {exc}"],
+            "warnings": [],
+        }
+        save_json(Path(args.output), report)
+        print(f"report written: {args.output}")
+        print("verdict=fail error_count=1 warning_count=0")
+        return 1
+
+    errors, warnings = validate_pin(pin, required_contracts)
+    verdict = "pass" if not errors else "fail"
+    report = {
+        "generated_at_utc": now_utc(),
+        "verdict": verdict,
+        "pin_path": args.pin,
+        "required_contracts": required_contracts,
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+    }
+    save_json(Path(args.output), report)
+
+    print(f"report written: {args.output}")
+    print(f"verdict={verdict} error_count={len(errors)} warning_count={len(warnings)}")
+    return 0 if verdict == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope
- Add observability-gateway repo-local CI workflow (`observability-local-ci`)
- Add contract pin validator and seeded-failure regression guard script
- Extend ingest smoke runner with `--output-dir` for clean CI/local execution
- Add deterministic replay assertions for `delay_and_replay`
- Update README with CI commands and contract pin remediation

## Linked Issues
- Closes #4

## Validation
- `python3 scripts/langfuse_ingest_smoke.py --scenario normal --run-id o11y-local-ci --output-dir /tmp/o11y/ingest`
- `python3 scripts/langfuse_ingest_smoke.py --scenario delay_and_replay --run-id o11y-local-ci --output-dir /tmp/o11y/ingest`
- `python3 scripts/validate_contract_pin.py --output /tmp/o11y/contract-pin-report.json`
- `bash scripts/test_observability_guardrails.sh`
