### PR TITLE
ci: make observability baseline always-on

### DIFF
--- a/.github/workflows/observability-local-ci.yml
+++ b/.github/workflows/observability-local-ci.yml
@@ -2,27 +2,9 @@ name: Observability Gateway Local CI
 
 on:
   pull_request:
-    paths:
-      - "config/**"
-      - "contracts/**"
-      - "docs/**"
-      - "scripts/**"
-      - "README.md"
-      - "requirements-dev.txt"
-      - ".gitignore"
-      - ".github/workflows/observability-local-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "config/**"
-      - "contracts/**"
-      - "docs/**"
-      - "scripts/**"
-      - "README.md"
-      - "requirements-dev.txt"
-      - ".gitignore"
-      - ".github/workflows/observability-local-ci.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- run observability local CI on every pull request and push to main
- remove path filters so the required `observability-local-ci` context is always emitted

## Scope
- `.github/workflows/observability-local-ci.yml`

## Linked Issues
- https://github.com/rather-not-work-on/platform-planningops/issues/123

## Validation
- workflow YAML parses locally

## Risks
- CI will run on more pull requests than before

## Review Checklist
- [x] required context name remains `observability-local-ci`
- [x] no behavior change beyond trigger coverage
