### PR TITLE
docs: define observability gateway topology and module ownership

### DIFF
--- a/.github/workflows/observability-local-ci.yml
+++ b/.github/workflows/observability-local-ci.yml
@@ -2,6 +2,14 @@ name: Observability Gateway Local CI
 
 on:
   pull_request:
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "contracts/**"
+      - "config/**"
+      - "scripts/**"
+      - "runtime-artifacts/README.md"
+      - ".github/workflows/observability-local-ci.yml"
   push:
     branches:
       - main
@@ -45,6 +53,9 @@ jobs:
           mkdir -p /tmp/o11y
           python3 scripts/validate_contract_pin.py \
             --output /tmp/o11y/contract-pin-report.json
+
+      - name: Verify topology README contract
+        run: bash scripts/test_module_readmes.sh
 
       - name: Seeded failure guard (deterministic replay + invalid pin)
         run: bash scripts/test_observability_guardrails.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ._*
 **/._*
 __pycache__/
-
-runtime-artifacts/
+runtime-artifacts/**
+!runtime-artifacts/
+!runtime-artifacts/README.md

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Local-first observability gateway baseline for UAP runtime.
 - `config/`: fallback/replay policy examples
 - `scripts/`: ingest smoke checks and local launcher
 - `runtime-artifacts/`: default local ingest smoke reports (gitignored)
+- `docs/`: repository topology and extension guidance
+
+Topology guide:
+- `docs/repo-topology.md`
+- `contracts/README.md`
+- `config/README.md`
+- `scripts/README.md`
+- `docs/runbook/README.md`
+- `runtime-artifacts/README.md`
 
 ## Policy Notes
 - default mode: local-first
@@ -48,6 +57,7 @@ Artifacts:
   - deterministic replay/dedupe assertions
   - contract pin validation (`scripts/validate_contract_pin.py`)
   - seeded failure guard (`scripts/test_observability_guardrails.sh`)
+  - topology/module README regression (`scripts/test_module_readmes.sh`)
 - evidence contract: `contracts/c5-observability-ingest-smoke-artifact.schema.json`
 - reason taxonomy: `config/observability-reason-taxonomy.json`
 - runbook: `docs/runbook/ingest-smoke-evidence-runbook.md`
@@ -66,3 +76,5 @@ When contract pin validation fails:
 python3 scripts/validate_contract_pin.py
 bash scripts/test_observability_guardrails.sh
 ```
+
+Generated local runtime outputs stay under `runtime-artifacts/` and remain gitignored except for the tracked module README.

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,13 @@
+# config
+
+## Responsibility
+Store static observability-gateway configuration and examples.
+
+## Contents
+- contract pin metadata
+- observability reason taxonomy
+- ingest/replay policy examples
+
+## Rules
+- config files must remain declarative
+- execution logic belongs in `scripts/`

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,12 @@
+# contracts
+
+## Responsibility
+Define observability-gateway-owned contract surfaces layered on top of shared platform contracts.
+
+## Contents
+- ingest contract schemas
+- smoke evidence schemas specific to this repository
+
+## Rules
+- contract definitions belong here, not in `scripts/`
+- shared cross-repo contract authority still lives in `platform-contracts`

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -1,0 +1,25 @@
+# platform-observability-gateway Topology
+
+## Purpose
+Fix the long-term repository boundaries before deeper observability implementation begins.
+
+## Module Map
+| Path | Responsibility | Allowed contents | Must not contain |
+| --- | --- | --- | --- |
+| `contracts/` | Observability-gateway-owned ingest/replay artifact contracts | schema files and contract docs | runtime code, generated reports |
+| `config/` | static ingest, replay, and contract-pin configuration | JSON examples and policy metadata | executable logic, runtime evidence |
+| `scripts/` | smoke checks, launch helpers, validators | repeatable local tooling and tests | mixed business logic without contract boundaries |
+| `docs/runbook/` | operator guidance for ingest/replay evidence and remediation | runbooks and procedures | contracts, runtime outputs |
+| `runtime-artifacts/` | gitignored local ingest/launcher evidence root | local smoke and launcher outputs plus tracked README | committed runtime reports |
+
+## Extension Rules
+1. Add contract/interface changes in `contracts/`.
+2. Add ingest/replay policy changes in `config/`.
+3. Put repeatable launch/smoke/validation tooling in `scripts/`.
+4. Keep operator procedures in `docs/runbook/`.
+5. Keep runtime evidence external to Git under `runtime-artifacts/`.
+
+## Ownership Boundary
+- `platform-observability-gateway` owns ingest/replay evidence behavior and repo-local validation.
+- Shared contract shape comes from `platform-contracts`.
+- Planning/orchestration policy belongs upstream in `platform-planningops`.

--- a/docs/runbook/README.md
+++ b/docs/runbook/README.md
@@ -1,0 +1,11 @@
+# runbook
+
+## Responsibility
+Keep operator-facing remediation and usage guidance for ingest/replay flows.
+
+## Contents
+- ingest smoke evidence runbooks
+- replay/backfill remediation notes
+
+## Rules
+- procedures live here; executable logic stays in `scripts/`

--- a/runtime-artifacts/README.md
+++ b/runtime-artifacts/README.md
@@ -1,0 +1,12 @@
+# runtime-artifacts
+
+## Responsibility
+Tracked boundary marker for gitignored local runtime outputs.
+
+## Contents
+- untracked ingest smoke evidence JSON
+- untracked launcher outputs
+
+## Rules
+- keep generated outputs out of Git
+- this README is the only tracked file in this directory tree

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,14 @@
+# scripts
+
+## Responsibility
+Host repeatable local ingest/replay smoke, validation, and launcher tooling.
+
+## Contents
+- ingest smoke scenarios
+- evidence validators
+- contract pin validation
+- stack launcher helpers
+
+## Rules
+- scripts should emit runtime output into `runtime-artifacts/` or `/tmp`, not Git-tracked paths
+- repository topology drift must be caught by `test_module_readmes.sh`

--- a/scripts/test_module_readmes.sh
+++ b/scripts/test_module_readmes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_files=(
+  "docs/repo-topology.md"
+  "contracts/README.md"
+  "config/README.md"
+  "scripts/README.md"
+  "docs/runbook/README.md"
+  "runtime-artifacts/README.md"
+)
+
+for path in "${required_files[@]}"; do
+  if [[ ! -f "$path" ]]; then
+    echo "missing required topology file: $path"
+    exit 1
+  fi
+done
+
+grep -q '`docs/repo-topology.md`' README.md
+grep -q '`runtime-artifacts/README.md`' README.md
+grep -q '| `contracts/` |' docs/repo-topology.md
+grep -q '| `config/` |' docs/repo-topology.md
+grep -q '| `scripts/` |' docs/repo-topology.md
+grep -q '| `docs/runbook/` |' docs/repo-topology.md
+grep -q '| `runtime-artifacts/` |' docs/repo-topology.md
+
+echo "observability module README topology contract ok"


### PR DESCRIPTION
## Summary
- add a canonical topology guide for `platform-observability-gateway`
- add module README files for contracts, config, scripts, runbook, and runtime artifacts
- add a regression check so topology/module docs stay present

## Scope
- root README, repo topology guide, and module READMEs
- local CI path filters and topology README contract test
- gitignore adjustment so only `runtime-artifacts/README.md` is tracked

## Linked Issues
- #8

## Validation
- bash scripts/test_module_readmes.sh
- python3 scripts/validate_contract_pin.py
- bash scripts/test_observability_guardrails.sh

## Risks
- workflow now triggers on topology/readme changes, increasing doc-driven CI runs
- tracked `runtime-artifacts/README.md` relies on ignore rules staying precise

## Review Checklist
- [ ] topology guide matches actual observability repo boundaries
- [ ] runtime artifact residency stays gitignored except for the tracked README
- [ ] module README contract is strict enough to prevent drift