### PR TITLE
feat: add wave2 telemetry runtime skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Topology guide:
 - `docs/runbook/README.md`
 - `runtime-artifacts/README.md`
 
+## Workspace Bootstrap
+- `package.json`
+- `pnpm-workspace.yaml`
+- `tsconfig.base.json`
+- `services/telemetry-gateway/`
+- `sinks/langfuse-sink/`
+- `buffer/replay-worker/`
+
+The workspace bootstrap is intentionally thin in this step.
+
+- current Python scripts remain smoke and launcher tooling
+- local runtime outputs stay under `runtime-artifacts/`
+- external sink or replay expansion stays in follow-up cards
+
 ## Policy Notes
 - default mode: local-first
 - fallback mode: local file buffer + replay

--- a/buffer/replay-worker/README.md
+++ b/buffer/replay-worker/README.md
@@ -1,0 +1,6 @@
+# replay-worker
+
+Own replay and local buffer recovery flow.
+
+- do not leak sink implementation details upstream
+- remote backfill logic stays out of this scaffold step

--- a/buffer/replay-worker/package.json
+++ b/buffer/replay-worker/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rather-not-work-on/replay-worker",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/buffer/replay-worker/src/file_buffer.ts
+++ b/buffer/replay-worker/src/file_buffer.ts
@@ -1,0 +1,8 @@
+export class FileBuffer {
+  append(eventName: string): { buffered: boolean; eventName: string } {
+    return {
+      buffered: true,
+      eventName,
+    };
+  }
+}

--- a/buffer/replay-worker/src/index.ts
+++ b/buffer/replay-worker/src/index.ts
@@ -1,0 +1,2 @@
+export { FileBuffer } from "./file_buffer.js";
+export { ReplayWorker } from "./replay_worker.js";

--- a/buffer/replay-worker/src/replay_worker.ts
+++ b/buffer/replay-worker/src/replay_worker.ts
@@ -1,0 +1,8 @@
+export class ReplayWorker {
+  replay(batchId: string): { replayed: boolean; batchId: string } {
+    return {
+      replayed: true,
+      batchId,
+    };
+  }
+}

--- a/buffer/replay-worker/tsconfig.json
+++ b/buffer/replay-worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -3,11 +3,16 @@
 ## Purpose
 Fix the long-term repository boundaries before deeper observability implementation begins.
 
+Workspace root descriptors may be added before runtime wiring is implemented. The first scaffold step introduces `services/`, `sinks/`, and `buffer/` package roots.
+
 ## Module Map
 | Path | Responsibility | Allowed contents | Must not contain |
 | --- | --- | --- | --- |
 | `contracts/` | Observability-gateway-owned ingest/replay artifact contracts | schema files and contract docs | runtime code, generated reports |
 | `config/` | static ingest, replay, and contract-pin configuration | JSON examples and policy metadata | executable logic, runtime evidence |
+| `services/` | ingest gateway service layer | service packages, package README files, TypeScript source | project policy, generated artifacts |
+| `sinks/` | external observability sink adapters | sink packages, package README files, TypeScript source | replay policy, generated evidence |
+| `buffer/` | replay and local buffering workers | worker packages, package README files, TypeScript source | external sink ownership |
 | `scripts/` | smoke checks, launch helpers, validators | repeatable local tooling and tests | mixed business logic without contract boundaries |
 | `docs/runbook/` | operator guidance for ingest/replay evidence and remediation | runbooks and procedures | contracts, runtime outputs |
 | `runtime-artifacts/` | gitignored local ingest/launcher evidence root | local smoke and launcher outputs plus tracked README | committed runtime reports |
@@ -15,9 +20,12 @@ Fix the long-term repository boundaries before deeper observability implementati
 ## Extension Rules
 1. Add contract/interface changes in `contracts/`.
 2. Add ingest/replay policy changes in `config/`.
-3. Put repeatable launch/smoke/validation tooling in `scripts/`.
-4. Keep operator procedures in `docs/runbook/`.
-5. Keep runtime evidence external to Git under `runtime-artifacts/`.
+3. Add ingest gateway code in `services/`.
+4. Add sink adapters in `sinks/`.
+5. Add replay and buffer workers in `buffer/`.
+6. Put repeatable launch/smoke/validation tooling in `scripts/`.
+7. Keep operator procedures in `docs/runbook/`.
+8. Keep runtime evidence external to Git under `runtime-artifacts/`.
 
 ## Ownership Boundary
 - `platform-observability-gateway` owns ingest/replay evidence behavior and repo-local validation.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rather-not-work-on/platform-observability-gateway",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Workspace bootstrap for the observability gateway runtime skeleton.",
+  "scripts": {
+    "typecheck": "pnpm -r exec tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "services/*"
+  - "sinks/*"
+  - "buffer/*"

--- a/services/telemetry-gateway/README.md
+++ b/services/telemetry-gateway/README.md
@@ -1,0 +1,6 @@
+# telemetry-gateway
+
+Own ingest normalization and dispatch decisions.
+
+- replay and sink specifics stay in sibling packages
+- planningops policy stays upstream

--- a/services/telemetry-gateway/package.json
+++ b/services/telemetry-gateway/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rather-not-work-on/telemetry-gateway",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/services/telemetry-gateway/src/index.ts
+++ b/services/telemetry-gateway/src/index.ts
@@ -1,0 +1,1 @@
+export { TelemetryGateway } from "./telemetry_gateway.js";

--- a/services/telemetry-gateway/src/telemetry_gateway.ts
+++ b/services/telemetry-gateway/src/telemetry_gateway.ts
@@ -1,0 +1,8 @@
+export class TelemetryGateway {
+  ingest(eventName: string): { accepted: boolean; eventName: string } {
+    return {
+      accepted: true,
+      eventName,
+    };
+  }
+}

--- a/services/telemetry-gateway/tsconfig.json
+++ b/services/telemetry-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/sinks/langfuse-sink/README.md
+++ b/sinks/langfuse-sink/README.md
@@ -1,0 +1,6 @@
+# langfuse-sink
+
+Own the external LangFuse delivery boundary.
+
+- do not own replay policy
+- alternate sinks stay out of this scaffold step

--- a/sinks/langfuse-sink/package.json
+++ b/sinks/langfuse-sink/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rather-not-work-on/langfuse-sink",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/sinks/langfuse-sink/src/index.ts
+++ b/sinks/langfuse-sink/src/index.ts
@@ -1,0 +1,1 @@
+export { LangfuseSink } from "./langfuse_sink.js";

--- a/sinks/langfuse-sink/src/langfuse_sink.ts
+++ b/sinks/langfuse-sink/src/langfuse_sink.ts
@@ -1,0 +1,8 @@
+export class LangfuseSink {
+  deliver(eventName: string): { delivered: boolean; eventName: string } {
+    return {
+      delivered: true,
+      eventName,
+    };
+  }
+}

--- a/sinks/langfuse-sink/tsconfig.json
+++ b/sinks/langfuse-sink/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "composite": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add workspace root descriptors for observability runtime scaffolding
- add telemetry gateway, langfuse sink, and replay worker package skeletons
- update README and repo topology for the new service/sink/buffer split

## Validation
- bash scripts/test_module_readmes.sh
- python3 scripts/validate_contract_pin.py --output /tmp/o11y-contract-pin-report.json
- bash scripts/test_observability_guardrails.sh

Refs rather-not-work-on/platform-planningops#160