### PR TITLE
chore: establish wave3 build baseline for observability gateway

### DIFF
--- a/.github/workflows/observability-local-ci.yml
+++ b/.github/workflows/observability-local-ci.yml
@@ -3,10 +3,18 @@ name: Observability Gateway Local CI
 on:
   pull_request:
     paths:
+      - ".gitignore"
       - "README.md"
       - "docs/**"
       - "contracts/**"
       - "config/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tsconfig.base.json"
+      - "services/**"
+      - "sinks/**"
+      - "buffer/**"
       - "scripts/**"
       - "runtime-artifacts/README.md"
       - ".github/workflows/observability-local-ci.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ._*
 **/._*
 __pycache__/
+node_modules/
+**/node_modules/
+*.tsbuildinfo
 runtime-artifacts/**
 !runtime-artifacts/
 !runtime-artifacts/README.md

--- a/buffer/replay-worker/package.json
+++ b/buffer/replay-worker/package.json
@@ -2,5 +2,7 @@
   "name": "@rather-not-work-on/replay-worker",
   "private": true,
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "exports": "./src/index.ts",
+  "types": "./src/index.ts"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  buffer/replay-worker: {}
+
+  services/telemetry-gateway: {}
+
+  sinks/langfuse-sink: {}
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/services/telemetry-gateway/package.json
+++ b/services/telemetry-gateway/package.json
@@ -2,5 +2,7 @@
   "name": "@rather-not-work-on/telemetry-gateway",
   "private": true,
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "exports": "./src/index.ts",
+  "types": "./src/index.ts"
 }

--- a/sinks/langfuse-sink/package.json
+++ b/sinks/langfuse-sink/package.json
@@ -2,5 +2,7 @@
   "name": "@rather-not-work-on/langfuse-sink",
   "private": true,
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "exports": "./src/index.ts",
+  "types": "./src/index.ts"
 }


### PR DESCRIPTION
## Summary
- add the first committed pnpm lockfile for the observability workspace
- normalize service, sink, and replay package manifests with exports/types entrypoints
- ignore local node_modules and tsbuildinfo outputs so build bootstrap stays clean

## Validation
- npm exec --yes pnpm@9.15.9 -- install
- npm exec --yes pnpm@9.15.9 -- typecheck

Refs rather-not-work-on/platform-planningops#166