### PR TITLE
feat: add telemetry ingest port surface

### DIFF
--- a/services/telemetry-gateway/README.md
+++ b/services/telemetry-gateway/README.md
@@ -2,5 +2,6 @@
 
 Own ingest normalization and dispatch decisions.
 
-- replay and sink specifics stay in sibling packages
+- expose the repo-owned telemetry envelope and ingest/buffer/sink ports here
+- replay and sink specifics stay in sibling packages and implement these interfaces later
 - planningops policy stays upstream

--- a/services/telemetry-gateway/src/index.ts
+++ b/services/telemetry-gateway/src/index.ts
@@ -1,1 +1,11 @@
 export { TelemetryGateway } from "./telemetry_gateway.js";
+export type {
+  TelemetryBufferAppendOutcome,
+  TelemetryBufferAppendPort,
+  TelemetryEnvelope,
+  TelemetryIngestOutcome,
+  TelemetryIngestPort,
+  TelemetryIngestRequest,
+  TelemetrySinkDeliveryOutcome,
+  TelemetrySinkDeliveryPort,
+} from "./telemetry_ports.js";

--- a/services/telemetry-gateway/src/telemetry_gateway.ts
+++ b/services/telemetry-gateway/src/telemetry_gateway.ts
@@ -1,8 +1,29 @@
-export class TelemetryGateway {
-  ingest(eventName: string): { accepted: boolean; eventName: string } {
+import type {
+  TelemetryBufferAppendPort,
+  TelemetryIngestOutcome,
+  TelemetryIngestPort,
+  TelemetryIngestRequest,
+  TelemetrySinkDeliveryPort,
+} from "./telemetry_ports.js";
+
+export interface TelemetryGatewayDependencies {
+  buffer?: TelemetryBufferAppendPort;
+  sink?: TelemetrySinkDeliveryPort;
+}
+
+export class TelemetryGateway implements TelemetryIngestPort {
+  constructor(private readonly dependencies: TelemetryGatewayDependencies = {}) {}
+
+  ingest(request: TelemetryIngestRequest): TelemetryIngestOutcome {
+    const { envelope } = request;
+
+    this.dependencies.buffer?.append(envelope);
+    this.dependencies.sink?.deliver(envelope);
+
     return {
       accepted: true,
-      eventName,
+      runId: envelope.runId,
+      eventName: envelope.eventName,
     };
   }
 }

--- a/services/telemetry-gateway/src/telemetry_ports.ts
+++ b/services/telemetry-gateway/src/telemetry_ports.ts
@@ -1,0 +1,40 @@
+export interface TelemetryEnvelope {
+  runId: string;
+  eventName: string;
+  detail?: string;
+  traceId?: string;
+}
+
+export interface TelemetryIngestRequest {
+  envelope: TelemetryEnvelope;
+}
+
+export interface TelemetryIngestOutcome {
+  accepted: boolean;
+  runId: string;
+  eventName: string;
+}
+
+export interface TelemetryBufferAppendOutcome {
+  buffered: boolean;
+  runId: string;
+  eventName: string;
+}
+
+export interface TelemetrySinkDeliveryOutcome {
+  delivered: boolean;
+  runId: string;
+  eventName: string;
+}
+
+export interface TelemetryIngestPort {
+  ingest(request: TelemetryIngestRequest): TelemetryIngestOutcome;
+}
+
+export interface TelemetryBufferAppendPort {
+  append(envelope: TelemetryEnvelope): TelemetryBufferAppendOutcome;
+}
+
+export interface TelemetrySinkDeliveryPort {
+  deliver(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome;
+}


### PR DESCRIPTION
## Summary
- add repo-owned telemetry envelope and ingest/buffer/sink port types to telemetry-gateway
- update TelemetryGateway to implement the typed ingest port with optional buffer and sink dependencies
- document telemetry-gateway as the public ingest surface ahead of replay/sink adoption

## Validation
- npm exec --yes pnpm@9.15.9 -- install
- npm exec --yes pnpm@9.15.9 -- typecheck
- bash scripts/test_module_readmes.sh
- git diff --check

Closes rather-not-work-on/platform-planningops#184