### PR TITLE
feat: adopt typed replay and sink ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The workspace bootstrap is intentionally thin in this step.
 
 - current Python scripts remain smoke and launcher tooling
 - local runtime outputs stay under `runtime-artifacts/`
+- telemetry-gateway now owns the ingest envelope and shared replay/sink port surface
 - external sink or replay expansion stays in follow-up cards
 
 ## Policy Notes

--- a/buffer/replay-worker/README.md
+++ b/buffer/replay-worker/README.md
@@ -2,5 +2,6 @@
 
 Own replay and local buffer recovery flow.
 
+- consume sink delivery through the telemetry-gateway port surface
 - do not leak sink implementation details upstream
 - remote backfill logic stays out of this scaffold step

--- a/buffer/replay-worker/package.json
+++ b/buffer/replay-worker/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "dependencies": {
+    "@rather-not-work-on/telemetry-gateway": "workspace:*"
+  },
   "exports": "./src/index.ts",
   "types": "./src/index.ts"
 }

--- a/buffer/replay-worker/src/file_buffer.ts
+++ b/buffer/replay-worker/src/file_buffer.ts
@@ -1,8 +1,11 @@
-export class FileBuffer {
-  append(eventName: string): { buffered: boolean; eventName: string } {
+import type { TelemetryBufferAppendOutcome, TelemetryBufferAppendPort, TelemetryEnvelope } from "@rather-not-work-on/telemetry-gateway";
+
+export class FileBuffer implements TelemetryBufferAppendPort {
+  append(envelope: TelemetryEnvelope): TelemetryBufferAppendOutcome {
     return {
       buffered: true,
-      eventName,
+      runId: envelope.runId,
+      eventName: envelope.eventName,
     };
   }
 }

--- a/buffer/replay-worker/src/index.ts
+++ b/buffer/replay-worker/src/index.ts
@@ -1,2 +1,5 @@
 export { FileBuffer } from "./file_buffer.js";
 export { ReplayWorker } from "./replay_worker.js";
+export type { ReplayOutcome, ReplayWorkerDependencies } from "./replay_worker.js";
+export type { TelemetryReplayBatch } from "./replay_batch.js";
+export type { ReplayReason } from "./replay_reason.js";

--- a/buffer/replay-worker/src/replay_batch.ts
+++ b/buffer/replay-worker/src/replay_batch.ts
@@ -1,0 +1,6 @@
+import type { TelemetryEnvelope } from "@rather-not-work-on/telemetry-gateway";
+
+export interface TelemetryReplayBatch {
+  batchId: string;
+  events: TelemetryEnvelope[];
+}

--- a/buffer/replay-worker/src/replay_reason.ts
+++ b/buffer/replay-worker/src/replay_reason.ts
@@ -1,0 +1,1 @@
+export type ReplayReason = "delay_replay" | "buffer_recovery" | "manual_replay";

--- a/buffer/replay-worker/src/replay_worker.ts
+++ b/buffer/replay-worker/src/replay_worker.ts
@@ -1,8 +1,30 @@
+import type { TelemetrySinkDeliveryPort } from "@rather-not-work-on/telemetry-gateway";
+
+import type { ReplayReason } from "./replay_reason.js";
+import type { TelemetryReplayBatch } from "./replay_batch.js";
+
+export interface ReplayWorkerDependencies {
+  sink: TelemetrySinkDeliveryPort;
+}
+
+export interface ReplayOutcome {
+  replayed: boolean;
+  batchId: string;
+  reason: ReplayReason;
+}
+
 export class ReplayWorker {
-  replay(batchId: string): { replayed: boolean; batchId: string } {
+  constructor(private readonly dependencies: ReplayWorkerDependencies) {}
+
+  replay(batch: TelemetryReplayBatch, reason: ReplayReason = "delay_replay"): ReplayOutcome {
+    for (const event of batch.events) {
+      this.dependencies.sink.deliver(event);
+    }
+
     return {
       replayed: true,
-      batchId,
+      batchId: batch.batchId,
+      reason,
     };
   }
 }

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -31,3 +31,4 @@ Workspace root descriptors may be added before runtime wiring is implemented. Th
 - `platform-observability-gateway` owns ingest/replay evidence behavior and repo-local validation.
 - Shared contract shape comes from `platform-contracts`.
 - Planning/orchestration policy belongs upstream in `platform-planningops`.
+- `services/telemetry-gateway` defines the public ingest and replay/sink port surface consumed by sibling packages.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,19 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
-  buffer/replay-worker: {}
+  buffer/replay-worker:
+    dependencies:
+      '@rather-not-work-on/telemetry-gateway':
+        specifier: workspace:*
+        version: link:../../services/telemetry-gateway
 
   services/telemetry-gateway: {}
 
-  sinks/langfuse-sink: {}
+  sinks/langfuse-sink:
+    dependencies:
+      '@rather-not-work-on/telemetry-gateway':
+        specifier: workspace:*
+        version: link:../../services/telemetry-gateway
 
 packages:
 

--- a/sinks/langfuse-sink/README.md
+++ b/sinks/langfuse-sink/README.md
@@ -2,5 +2,6 @@
 
 Own the external LangFuse delivery boundary.
 
+- implement the telemetry sink delivery port only
 - do not own replay policy
 - alternate sinks stay out of this scaffold step

--- a/sinks/langfuse-sink/package.json
+++ b/sinks/langfuse-sink/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "dependencies": {
+    "@rather-not-work-on/telemetry-gateway": "workspace:*"
+  },
   "exports": "./src/index.ts",
   "types": "./src/index.ts"
 }

--- a/sinks/langfuse-sink/src/langfuse_sink.ts
+++ b/sinks/langfuse-sink/src/langfuse_sink.ts
@@ -1,8 +1,11 @@
-export class LangfuseSink {
-  deliver(eventName: string): { delivered: boolean; eventName: string } {
+import type { TelemetryEnvelope, TelemetrySinkDeliveryOutcome, TelemetrySinkDeliveryPort } from "@rather-not-work-on/telemetry-gateway";
+
+export class LangfuseSink implements TelemetrySinkDeliveryPort {
+  deliver(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
     return {
       delivered: true,
-      eventName,
+      runId: envelope.runId,
+      eventName: envelope.eventName,
     };
   }
 }


### PR DESCRIPTION
## Summary
- make replay-worker consume sink delivery through telemetry-gateway ports
- make file buffer and Langfuse sink implement the shared telemetry port surface
- document ingest -> replay -> sink ownership in repo docs and package READMEs

## Validation
- npm exec --yes pnpm@9.15.9 -- install
- npm exec --yes pnpm@9.15.9 -- typecheck
- bash scripts/test_module_readmes.sh
- git diff --check

Closes rather-not-work-on/platform-planningops#185