### PR TITLE
feat: add dispatch mode baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The workspace bootstrap is intentionally thin in this step.
 - current Python scripts remain smoke and launcher tooling
 - local runtime outputs stay under `runtime-artifacts/`
 - telemetry-gateway now owns the ingest envelope and shared replay/sink port surface
+- telemetry-gateway now owns the dispatch mode baseline that chooses buffer, sink, fanout, or noop
 - external sink or replay expansion stays in follow-up cards
 
 ## Policy Notes

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -32,3 +32,4 @@ Workspace root descriptors may be added before runtime wiring is implemented. Th
 - Shared contract shape comes from `platform-contracts`.
 - Planning/orchestration policy belongs upstream in `platform-planningops`.
 - `services/telemetry-gateway` defines the public ingest and replay/sink port surface consumed by sibling packages.
+- `services/telemetry-gateway` also owns the dispatch mode baseline that chooses buffer, sink, or fanout behavior.

--- a/services/telemetry-gateway/README.md
+++ b/services/telemetry-gateway/README.md
@@ -2,6 +2,7 @@
 
 Own ingest normalization and dispatch decisions.
 
+- derive a repo-owned dispatch mode before choosing buffer, sink, or fanout behavior
 - expose the repo-owned telemetry envelope and ingest/buffer/sink ports here
 - replay and sink specifics stay in sibling packages and implement these interfaces later
 - planningops policy stays upstream

--- a/services/telemetry-gateway/src/dispatch_mode.ts
+++ b/services/telemetry-gateway/src/dispatch_mode.ts
@@ -1,0 +1,39 @@
+import type { TelemetryBufferAppendPort, TelemetrySinkDeliveryPort } from "./telemetry_ports.js";
+
+export type TelemetryDispatchMode = "buffer_only" | "sink_only" | "fanout" | "noop";
+
+export interface DispatchModeDependencies {
+  buffer?: TelemetryBufferAppendPort;
+  sink?: TelemetrySinkDeliveryPort;
+}
+
+export function resolveDispatchMode(
+  requestedMode: TelemetryDispatchMode | undefined,
+  dependencies: DispatchModeDependencies,
+): TelemetryDispatchMode {
+  if (requestedMode === "buffer_only" && dependencies.buffer) {
+    return requestedMode;
+  }
+
+  if (requestedMode === "sink_only" && dependencies.sink) {
+    return requestedMode;
+  }
+
+  if (requestedMode === "fanout" && dependencies.buffer && dependencies.sink) {
+    return requestedMode;
+  }
+
+  if (dependencies.buffer && dependencies.sink) {
+    return "fanout";
+  }
+
+  if (dependencies.buffer) {
+    return "buffer_only";
+  }
+
+  if (dependencies.sink) {
+    return "sink_only";
+  }
+
+  return "noop";
+}

--- a/services/telemetry-gateway/src/index.ts
+++ b/services/telemetry-gateway/src/index.ts
@@ -1,4 +1,5 @@
 export { TelemetryGateway } from "./telemetry_gateway.js";
+export { resolveDispatchMode } from "./dispatch_mode.js";
 export type {
   TelemetryBufferAppendOutcome,
   TelemetryBufferAppendPort,
@@ -9,3 +10,4 @@ export type {
   TelemetrySinkDeliveryOutcome,
   TelemetrySinkDeliveryPort,
 } from "./telemetry_ports.js";
+export type { DispatchModeDependencies, TelemetryDispatchMode } from "./dispatch_mode.js";

--- a/services/telemetry-gateway/src/telemetry_gateway.ts
+++ b/services/telemetry-gateway/src/telemetry_gateway.ts
@@ -5,10 +5,12 @@ import type {
   TelemetryIngestRequest,
   TelemetrySinkDeliveryPort,
 } from "./telemetry_ports.js";
+import { resolveDispatchMode, type TelemetryDispatchMode } from "./dispatch_mode.js";
 
 export interface TelemetryGatewayDependencies {
   buffer?: TelemetryBufferAppendPort;
   sink?: TelemetrySinkDeliveryPort;
+  dispatchMode?: TelemetryDispatchMode;
 }
 
 export class TelemetryGateway implements TelemetryIngestPort {
@@ -16,12 +18,18 @@ export class TelemetryGateway implements TelemetryIngestPort {
 
   ingest(request: TelemetryIngestRequest): TelemetryIngestOutcome {
     const { envelope } = request;
+    const dispatchMode = resolveDispatchMode(this.dependencies.dispatchMode, this.dependencies);
 
-    this.dependencies.buffer?.append(envelope);
-    this.dependencies.sink?.deliver(envelope);
+    if (dispatchMode === "buffer_only" || dispatchMode === "fanout") {
+      this.dependencies.buffer?.append(envelope);
+    }
+
+    if (dispatchMode === "sink_only" || dispatchMode === "fanout") {
+      this.dependencies.sink?.deliver(envelope);
+    }
 
     return {
-      accepted: true,
+      accepted: dispatchMode !== "noop",
       runId: envelope.runId,
       eventName: envelope.eventName,
     };


### PR DESCRIPTION
## Summary
- add a telemetry-gateway owned dispatch mode helper
- route ingest behavior through buffer_only, sink_only, fanout, or noop decisions
- document dispatch mode ownership in observability docs

## Validation
- npm exec --yes pnpm@9.15.9 -- typecheck
- bash scripts/test_module_readmes.sh
- git diff --check

Closes rather-not-work-on/platform-planningops#192