### PR TITLE
feat(observability): add replay policy baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The workspace bootstrap is intentionally thin in this step.
 - local runtime outputs stay under `runtime-artifacts/`
 - telemetry-gateway now owns the ingest envelope and shared replay/sink port surface
 - telemetry-gateway now owns the dispatch mode baseline that chooses buffer, sink, fanout, or noop
+- replay-worker now owns the replay policy baseline that chooses replay or skip before sink delivery
 - external sink or replay expansion stays in follow-up cards
 
 ## Policy Notes

--- a/buffer/replay-worker/README.md
+++ b/buffer/replay-worker/README.md
@@ -2,6 +2,7 @@
 
 Own replay and local buffer recovery flow.
 
+- choose replay vs skip through a repo-owned replay policy before touching the sink
 - consume sink delivery through the telemetry-gateway port surface
 - do not leak sink implementation details upstream
 - remote backfill logic stays out of this scaffold step

--- a/buffer/replay-worker/src/index.ts
+++ b/buffer/replay-worker/src/index.ts
@@ -1,5 +1,7 @@
 export { FileBuffer } from "./file_buffer.js";
 export { ReplayWorker } from "./replay_worker.js";
+export { resolveReplayPolicy } from "./replay_policy.js";
 export type { ReplayOutcome, ReplayWorkerDependencies } from "./replay_worker.js";
 export type { TelemetryReplayBatch } from "./replay_batch.js";
 export type { ReplayReason } from "./replay_reason.js";
+export type { ReplayDispatchMode, ReplayPolicy, ReplayPolicyInput } from "./replay_policy.js";

--- a/buffer/replay-worker/src/replay_policy.ts
+++ b/buffer/replay-worker/src/replay_policy.ts
@@ -1,0 +1,36 @@
+import type { TelemetryReplayBatch } from "./replay_batch.js";
+import type { ReplayReason } from "./replay_reason.js";
+
+export type ReplayDispatchMode = "replay" | "skip";
+
+export interface ReplayPolicyInput {
+  batch: TelemetryReplayBatch;
+  reason: ReplayReason;
+  maxBatchSize?: number;
+}
+
+export interface ReplayPolicy {
+  dispatchMode: ReplayDispatchMode;
+  reason: ReplayReason;
+}
+
+export function resolveReplayPolicy(input: ReplayPolicyInput): ReplayPolicy {
+  if (input.batch.events.length === 0) {
+    return {
+      dispatchMode: "skip",
+      reason: input.reason,
+    };
+  }
+
+  if (input.maxBatchSize && input.batch.events.length > input.maxBatchSize) {
+    return {
+      dispatchMode: "skip",
+      reason: input.reason,
+    };
+  }
+
+  return {
+    dispatchMode: "replay",
+    reason: input.reason,
+  };
+}

--- a/buffer/replay-worker/src/replay_worker.ts
+++ b/buffer/replay-worker/src/replay_worker.ts
@@ -2,9 +2,11 @@ import type { TelemetrySinkDeliveryPort } from "@rather-not-work-on/telemetry-ga
 
 import type { ReplayReason } from "./replay_reason.js";
 import type { TelemetryReplayBatch } from "./replay_batch.js";
+import { resolveReplayPolicy } from "./replay_policy.js";
 
 export interface ReplayWorkerDependencies {
   sink: TelemetrySinkDeliveryPort;
+  maxBatchSize?: number;
 }
 
 export interface ReplayOutcome {
@@ -17,6 +19,19 @@ export class ReplayWorker {
   constructor(private readonly dependencies: ReplayWorkerDependencies) {}
 
   replay(batch: TelemetryReplayBatch, reason: ReplayReason = "delay_replay"): ReplayOutcome {
+    const replayPolicy = resolveReplayPolicy({
+      batch,
+      reason,
+      maxBatchSize: this.dependencies.maxBatchSize,
+    });
+    if (replayPolicy.dispatchMode === "skip") {
+      return {
+        replayed: false,
+        batchId: batch.batchId,
+        reason: replayPolicy.reason,
+      };
+    }
+
     for (const event of batch.events) {
       this.dependencies.sink.deliver(event);
     }
@@ -24,7 +39,7 @@ export class ReplayWorker {
     return {
       replayed: true,
       batchId: batch.batchId,
-      reason,
+      reason: replayPolicy.reason,
     };
   }
 }

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -33,3 +33,4 @@ Workspace root descriptors may be added before runtime wiring is implemented. Th
 - Planning/orchestration policy belongs upstream in `platform-planningops`.
 - `services/telemetry-gateway` defines the public ingest and replay/sink port surface consumed by sibling packages.
 - `services/telemetry-gateway` also owns the dispatch mode baseline that chooses buffer, sink, or fanout behavior.
+- `buffer/replay-worker` owns the replay policy baseline that chooses whether a batch should be replayed before invoking the sink.


### PR DESCRIPTION
## Summary
- add a replay policy helper for replay-worker
- allow replay-worker to skip empty or oversized batches before sink delivery
- document replay policy ownership in the repo topology and package README

## Testing
- npm exec --yes pnpm@9.15.9 -- typecheck
- bash scripts/test_module_readmes.sh
- git diff --check

Closes #197