### PR TITLE
feat(observability): add delivery policy baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The workspace bootstrap is intentionally thin in this step.
 - telemetry-gateway now owns the ingest envelope and shared replay/sink port surface
 - telemetry-gateway now owns the dispatch mode baseline that chooses buffer, sink, fanout, or noop
 - replay-worker now owns the replay policy baseline that chooses replay or skip before sink delivery
+- langfuse-sink now owns the delivery policy baseline that normalizes sink delivery outcomes
 - external sink or replay expansion stays in follow-up cards
 
 ## Policy Notes

--- a/docs/repo-topology.md
+++ b/docs/repo-topology.md
@@ -34,3 +34,4 @@ Workspace root descriptors may be added before runtime wiring is implemented. Th
 - `services/telemetry-gateway` defines the public ingest and replay/sink port surface consumed by sibling packages.
 - `services/telemetry-gateway` also owns the dispatch mode baseline that chooses buffer, sink, or fanout behavior.
 - `buffer/replay-worker` owns the replay policy baseline that chooses whether a batch should be replayed before invoking the sink.
+- `sinks/langfuse-sink` owns the delivery policy baseline that normalizes sink delivery outcomes before returning.

--- a/sinks/langfuse-sink/README.md
+++ b/sinks/langfuse-sink/README.md
@@ -2,6 +2,7 @@
 
 Own the external LangFuse delivery boundary.
 
+- normalize sink delivery outcomes through a local delivery policy helper
 - implement the telemetry sink delivery port only
 - do not own replay policy
 - alternate sinks stay out of this scaffold step

--- a/sinks/langfuse-sink/src/delivery_policy.ts
+++ b/sinks/langfuse-sink/src/delivery_policy.ts
@@ -1,0 +1,15 @@
+import type { TelemetryEnvelope, TelemetrySinkDeliveryOutcome } from "@rather-not-work-on/telemetry-gateway";
+
+function normalizeEventName(eventName: string): string {
+  return eventName.trim() || "telemetry.unknown";
+}
+
+export function buildDeliveryOutcome(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
+  const eventName = normalizeEventName(envelope.eventName);
+
+  return {
+    delivered: envelope.runId.trim().length > 0,
+    runId: envelope.runId,
+    eventName,
+  };
+}

--- a/sinks/langfuse-sink/src/index.ts
+++ b/sinks/langfuse-sink/src/index.ts
@@ -1,1 +1,2 @@
+export { buildDeliveryOutcome } from "./delivery_policy.js";
 export { LangfuseSink } from "./langfuse_sink.js";

--- a/sinks/langfuse-sink/src/langfuse_sink.ts
+++ b/sinks/langfuse-sink/src/langfuse_sink.ts
@@ -1,11 +1,9 @@
 import type { TelemetryEnvelope, TelemetrySinkDeliveryOutcome, TelemetrySinkDeliveryPort } from "@rather-not-work-on/telemetry-gateway";
 
+import { buildDeliveryOutcome } from "./delivery_policy.js";
+
 export class LangfuseSink implements TelemetrySinkDeliveryPort {
   deliver(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
-    return {
-      delivered: true,
-      runId: envelope.runId,
-      eventName: envelope.eventName,
-    };
+    return buildDeliveryOutcome(envelope);
   }
 }


### PR DESCRIPTION
## Summary
- add a langfuse-sink delivery policy helper
- normalize sink delivery outcomes instead of returning pass-through values
- document delivery policy ownership in the sink docs

## Testing
- npm exec --yes pnpm@9.15.9 -- typecheck
- bash scripts/test_module_readmes.sh
- git diff --check

Closes #203
