### PR TITLE
chore(observability): add PR link guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+- What changed and why?
+
+## Scope
+- Service/sink/buffer/config/docs:
+- Scripts/contracts:
+- `.github/` workflows:
+
+## Linked Issues
+- Closes rather-not-work-on/platform-planningops#
+- Related #
+
+## Validation
+- [ ] `npm exec --yes pnpm@9.15.9 -- typecheck`
+- [ ] `bash scripts/test_module_readmes.sh`
+- [ ] Additional checks (if any):
+
+## Risks
+- Risk:
+- Rollback:
+
+## Review Checklist
+- [ ] Changes are from a feature branch.
+- [ ] PR includes a repo-qualified planningops issue ref.
+- [ ] README or topology guidance updated if workflow expectations changed.
+- [ ] Validation commands were run locally.

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,50 @@
+name: pr-review-gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  template-and-link-check:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR description structure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request.body || "").trim();
+            const requiredSections = [
+              "## Summary",
+              "## Scope",
+              "## Linked Issues",
+              "## Validation",
+              "## Risks",
+              "## Review Checklist",
+            ];
+
+            const missing = requiredSections.filter((section) => !body.includes(section));
+            const hasPlanningOpsRef =
+              /rather-not-work-on\/platform-planningops#\d+|https:\/\/github\.com\/rather-not-work-on\/platform-planningops\/issues\/\d+/i.test(
+                body
+              );
+
+            if (!hasPlanningOpsRef) {
+              missing.push(
+                "repo-qualified PlanningOps issue reference (`rather-not-work-on/platform-planningops#123` or issue URL)"
+              );
+            }
+
+            if (missing.length > 0) {
+              core.setFailed(
+                [
+                  "PR body is missing required content:",
+                  ...missing.map((item) => `- ${item}`),
+                  "",
+                  "Use `.github/pull_request_template.md`.",
+                ].join("\n")
+              );
+              return;
+            }
+
+            core.notice("PR body structure validation passed.");

--- a/README.md
+++ b/README.md
@@ -91,8 +91,14 @@ When contract pin validation fails:
 3. Re-run:
 
 ```bash
-python3 scripts/validate_contract_pin.py
-bash scripts/test_observability_guardrails.sh
+   python3 scripts/validate_contract_pin.py
+   bash scripts/test_observability_guardrails.sh
 ```
+
+## PR Hygiene
+- template: `.github/pull_request_template.md`
+- review gate: `.github/workflows/pr-review-gate.yml`
+- external repo PRs must include a repo-qualified planningops issue ref
+- example: `Closes rather-not-work-on/platform-planningops#209`
 
 Generated local runtime outputs stay under `runtime-artifacts/` and remain gitignored except for the tracked module README.


### PR DESCRIPTION
## Summary
- add a repo-local pull request template for observability gateway
- add a PR review gate that requires repo-qualified planningops issue refs
- document PR hygiene expectations in the root README

## Scope
- Service/sink/buffer/config/docs: README guidance only
- Scripts/contracts: none
- `.github/` workflows: add template and review gate

## Linked Issues
- Closes rather-not-work-on/platform-planningops#209
- Related #211

## Validation
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-review-gate.yml"); puts "yaml ok"'`
- [x] Additional checks (if any): none

## Risks
- Risk: template friction for very small PRs.
- Rollback: remove the workflow and template if it proves too strict.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
