### PR TITLE
feat: normalize observability telemetry envelopes

### DIFF
--- a/services/telemetry-gateway/README.md
+++ b/services/telemetry-gateway/README.md
@@ -2,6 +2,7 @@
 
 Own ingest normalization and dispatch decisions.
 
+- normalize inbound telemetry envelopes before dispatching to buffer or sink
 - derive a repo-owned dispatch mode before choosing buffer, sink, or fanout behavior
 - expose the repo-owned telemetry envelope and ingest/buffer/sink ports here
 - replay and sink specifics stay in sibling packages and implement these interfaces later

--- a/services/telemetry-gateway/src/envelope_policy.ts
+++ b/services/telemetry-gateway/src/envelope_policy.ts
@@ -1,0 +1,21 @@
+import type { TelemetryEnvelope } from "./telemetry_ports.js";
+
+function normalizeRequired(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+export function normalizeTelemetryEnvelope(envelope: TelemetryEnvelope): TelemetryEnvelope {
+  return {
+    ...envelope,
+    runId: normalizeRequired(envelope.runId, "unknown-run"),
+    missionId: normalizeRequired(envelope.missionId, "unknown-mission"),
+    eventName: normalizeRequired(envelope.eventName, "telemetry.unknown"),
+    detail: envelope.detail?.trim() || undefined,
+    taskId: envelope.taskId?.trim() || undefined,
+    handoffId: envelope.handoffId?.trim() || undefined,
+    traceId: envelope.traceId?.trim() || undefined,
+    reasonCode: envelope.reasonCode?.trim() || undefined,
+    source: envelope.source ?? "executor",
+  };
+}

--- a/services/telemetry-gateway/src/index.ts
+++ b/services/telemetry-gateway/src/index.ts
@@ -1,4 +1,5 @@
 export { TelemetryGateway } from "./telemetry_gateway.js";
+export { normalizeTelemetryEnvelope } from "./envelope_policy.js";
 export { resolveDispatchMode } from "./dispatch_mode.js";
 export type {
   TelemetryBufferAppendOutcome,

--- a/services/telemetry-gateway/src/telemetry_gateway.ts
+++ b/services/telemetry-gateway/src/telemetry_gateway.ts
@@ -6,6 +6,7 @@ import type {
   TelemetrySinkDeliveryPort,
 } from "./telemetry_ports.js";
 import { resolveDispatchMode, type TelemetryDispatchMode } from "./dispatch_mode.js";
+import { normalizeTelemetryEnvelope } from "./envelope_policy.js";
 
 export interface TelemetryGatewayDependencies {
   buffer?: TelemetryBufferAppendPort;
@@ -17,7 +18,7 @@ export class TelemetryGateway implements TelemetryIngestPort {
   constructor(private readonly dependencies: TelemetryGatewayDependencies = {}) {}
 
   ingest(request: TelemetryIngestRequest): TelemetryIngestOutcome {
-    const { envelope } = request;
+    const envelope = normalizeTelemetryEnvelope(request.envelope);
     const dispatchMode = resolveDispatchMode(this.dependencies.dispatchMode, this.dependencies);
 
     if (dispatchMode === "buffer_only" || dispatchMode === "fanout") {

--- a/services/telemetry-gateway/src/telemetry_ports.ts
+++ b/services/telemetry-gateway/src/telemetry_ports.ts
@@ -1,8 +1,14 @@
 export interface TelemetryEnvelope {
   runId: string;
+  missionId: string;
   eventName: string;
   detail?: string;
+  taskId?: string;
+  handoffId?: string;
   traceId?: string;
+  source?: "executor" | "orchestrator" | "provider" | "observability";
+  resultType?: "complete" | "partial" | "failed" | "canceled";
+  reasonCode?: string;
 }
 
 export interface TelemetryIngestRequest {

--- a/sinks/langfuse-sink/README.md
+++ b/sinks/langfuse-sink/README.md
@@ -2,7 +2,7 @@
 
 Own the external LangFuse delivery boundary.
 
-- normalize sink delivery outcomes through a local delivery policy helper
+- consume the shared telemetry envelope normalization before producing delivery outcomes
 - implement the telemetry sink delivery port only
 - do not own replay policy
 - alternate sinks stay out of this scaffold step

--- a/sinks/langfuse-sink/src/delivery_policy.ts
+++ b/sinks/langfuse-sink/src/delivery_policy.ts
@@ -1,15 +1,12 @@
 import type { TelemetryEnvelope, TelemetrySinkDeliveryOutcome } from "@rather-not-work-on/telemetry-gateway";
-
-function normalizeEventName(eventName: string): string {
-  return eventName.trim() || "telemetry.unknown";
-}
+import { normalizeTelemetryEnvelope } from "@rather-not-work-on/telemetry-gateway";
 
 export function buildDeliveryOutcome(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
-  const eventName = normalizeEventName(envelope.eventName);
+  const normalizedEnvelope = normalizeTelemetryEnvelope(envelope);
 
   return {
-    delivered: envelope.runId.trim().length > 0,
-    runId: envelope.runId,
-    eventName,
+    delivered: normalizedEnvelope.runId.length > 0,
+    runId: normalizedEnvelope.runId,
+    eventName: normalizedEnvelope.eventName,
   };
 }

--- a/sinks/langfuse-sink/src/langfuse_sink.ts
+++ b/sinks/langfuse-sink/src/langfuse_sink.ts
@@ -1,9 +1,14 @@
-import type { TelemetryEnvelope, TelemetrySinkDeliveryOutcome, TelemetrySinkDeliveryPort } from "@rather-not-work-on/telemetry-gateway";
+import type {
+  TelemetryEnvelope,
+  TelemetrySinkDeliveryOutcome,
+  TelemetrySinkDeliveryPort,
+} from "@rather-not-work-on/telemetry-gateway";
+import { normalizeTelemetryEnvelope } from "@rather-not-work-on/telemetry-gateway";
 
 import { buildDeliveryOutcome } from "./delivery_policy.js";
 
 export class LangfuseSink implements TelemetrySinkDeliveryPort {
   deliver(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
-    return buildDeliveryOutcome(envelope);
+    return buildDeliveryOutcome(normalizeTelemetryEnvelope(envelope));
   }
 }


### PR DESCRIPTION
## Summary
- add telemetry envelope normalization in the gateway boundary
- reuse normalized envelopes in Langfuse sink delivery outcomes
- align telemetry envelope fields with runtime wave payloads

## Scope
- telemetry gateway and langfuse sink boundary shaping
- no replay policy change

## Linked Issues
- Closes rather-not-work-on/platform-planningops#215
- Related rather-not-work-on/platform-planningops#216

## Validation
- python3 -m venv .venv.ci && . .venv.ci/bin/activate && python3 -m pip install -q -r requirements-dev.txt
- npx --yes pnpm@10 typecheck
- bash scripts/test_observability_guardrails.sh
- git diff --check

## Risks
- envelope defaults may hide blank inputs if downstream expects raw empties
- no live Langfuse transport in this PR

## Review Checklist
- [x] telemetry gateway normalizes before dispatch
- [x] sink delivery uses the shared normalized envelope
- [x] envelope fields are explicit enough for runtime event wiring