### PR TITLE
feat: add observability default composer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,18 @@ importers:
 
   services/telemetry-gateway: {}
 
+  services/telemetry-gateway-composer:
+    dependencies:
+      '@rather-not-work-on/langfuse-sink':
+        specifier: workspace:*
+        version: link:../../sinks/langfuse-sink
+      '@rather-not-work-on/replay-worker':
+        specifier: workspace:*
+        version: link:../../buffer/replay-worker
+      '@rather-not-work-on/telemetry-gateway':
+        specifier: workspace:*
+        version: link:../telemetry-gateway
+
   sinks/langfuse-sink:
     dependencies:
       '@rather-not-work-on/telemetry-gateway':

--- a/services/telemetry-gateway-composer/README.md
+++ b/services/telemetry-gateway-composer/README.md
@@ -1,0 +1,7 @@
+# telemetry-gateway-composer
+
+Compose the telemetry gateway with repo-local default buffer and sink implementations.
+
+- own default composition only
+- keep envelope normalization and dispatch in `telemetry-gateway`
+- keep sink and replay implementations in sibling packages

--- a/services/telemetry-gateway-composer/package.json
+++ b/services/telemetry-gateway-composer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@rather-not-work-on/telemetry-gateway-composer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "@rather-not-work-on/telemetry-gateway": "workspace:*",
+    "@rather-not-work-on/replay-worker": "workspace:*",
+    "@rather-not-work-on/langfuse-sink": "workspace:*"
+  },
+  "exports": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/services/telemetry-gateway-composer/src/default_telemetry_gateway.ts
+++ b/services/telemetry-gateway-composer/src/default_telemetry_gateway.ts
@@ -1,0 +1,29 @@
+import { LangfuseSink } from "@rather-not-work-on/langfuse-sink";
+import { FileBuffer } from "@rather-not-work-on/replay-worker";
+import {
+  TelemetryGateway,
+  type TelemetryBufferAppendPort,
+  type TelemetryDispatchMode,
+  type TelemetryGatewayDependencies,
+  type TelemetrySinkDeliveryPort,
+} from "@rather-not-work-on/telemetry-gateway";
+
+export interface DefaultTelemetryGatewayOptions {
+  buffer?: TelemetryBufferAppendPort;
+  sink?: TelemetrySinkDeliveryPort;
+  dispatchMode?: TelemetryDispatchMode;
+}
+
+export function buildDefaultTelemetryGatewayDependencies(
+  options: DefaultTelemetryGatewayOptions = {},
+): TelemetryGatewayDependencies {
+  return {
+    buffer: options.buffer ?? new FileBuffer(),
+    sink: options.sink ?? new LangfuseSink(),
+    dispatchMode: options.dispatchMode,
+  };
+}
+
+export function createDefaultTelemetryGateway(options: DefaultTelemetryGatewayOptions = {}): TelemetryGateway {
+  return new TelemetryGateway(buildDefaultTelemetryGatewayDependencies(options));
+}

--- a/services/telemetry-gateway-composer/src/index.ts
+++ b/services/telemetry-gateway-composer/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  buildDefaultTelemetryGatewayDependencies,
+  createDefaultTelemetryGateway,
+} from "./default_telemetry_gateway.js";
+export type { DefaultTelemetryGatewayOptions } from "./default_telemetry_gateway.js";

--- a/services/telemetry-gateway-composer/tsconfig.json
+++ b/services/telemetry-gateway-composer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/telemetry-gateway/src/index.ts
+++ b/services/telemetry-gateway/src/index.ts
@@ -12,3 +12,4 @@ export type {
   TelemetrySinkDeliveryPort,
 } from "./telemetry_ports.js";
 export type { DispatchModeDependencies, TelemetryDispatchMode } from "./dispatch_mode.js";
+export type { TelemetryGatewayDependencies } from "./telemetry_gateway.js";


### PR DESCRIPTION
## Summary
- add a repo-local composer package for default telemetry gateway assembly
- compose file buffer and Langfuse sink without reversing telemetry-gateway dependencies
- expose default telemetry gateway builders for later local infra wiring

## Scope
- observability composer package only

## Linked Issues
- Closes rather-not-work-on/platform-planningops#220
- Related rather-not-work-on/platform-planningops#221

## Validation
- npx --yes pnpm@10 install --ignore-scripts
- python3 -m venv .venv.ci && . .venv.ci/bin/activate && python3 -m pip install -q -r requirements-dev.txt
- npx --yes pnpm@10 typecheck
- bash scripts/test_observability_guardrails.sh
- git diff --check

## Risks
- default dispatch composition may look final even though env-driven wiring is still a later wave

## Review Checklist
- [x] composer package depends on gateway plus sink/buffer packages
- [x] telemetry-gateway itself does not depend on sink or replay packages
- [x] default gateway builders stay repo-local