### PR TITLE
feat(observability): add langfuse local composer baseline

### DIFF
--- a/services/telemetry-gateway-composer/src/default_langfuse_gateway.ts
+++ b/services/telemetry-gateway-composer/src/default_langfuse_gateway.ts
@@ -1,0 +1,69 @@
+import { FileBuffer } from "@rather-not-work-on/replay-worker";
+import { LangfuseSink, type LangfuseSinkProfile } from "@rather-not-work-on/langfuse-sink";
+import {
+  TelemetryGateway,
+  type TelemetryBufferAppendPort,
+  type TelemetryDispatchMode,
+  type TelemetrySinkDeliveryPort,
+} from "@rather-not-work-on/telemetry-gateway";
+
+export interface LangfuseRuntimeProfileSource {
+  execution_mode: string;
+  langfuse_host: string;
+  litellm_base_url?: string;
+  nanoclaw_endpoint?: string;
+}
+
+export interface LangfuseRuntimeProfileCatalog {
+  active_profile?: string;
+  profiles: Record<string, LangfuseRuntimeProfileSource>;
+}
+
+export interface LangfuseLocalRuntimeProfile {
+  profileName: string;
+  executionMode: string;
+  langfuseHost: string;
+}
+
+export interface DefaultLangfuseGatewayOptions {
+  profile: LangfuseLocalRuntimeProfile;
+  buffer?: TelemetryBufferAppendPort;
+  sink?: TelemetrySinkDeliveryPort;
+  dispatchMode?: TelemetryDispatchMode;
+}
+
+function buildLangfuseProfile(profile: LangfuseLocalRuntimeProfile): LangfuseSinkProfile {
+  return {
+    runtimeProfileName: profile.profileName,
+    host: profile.langfuseHost,
+    executionMode: profile.executionMode,
+  };
+}
+
+export function resolveLangfuseRuntimeProfile(
+  catalog: LangfuseRuntimeProfileCatalog,
+  requestedProfileName = catalog.active_profile,
+): LangfuseLocalRuntimeProfile {
+  if (!requestedProfileName) {
+    throw new Error("runtime profile name is required");
+  }
+
+  const rawProfile = catalog.profiles[requestedProfileName];
+  if (!rawProfile) {
+    throw new Error(`runtime profile '${requestedProfileName}' is not defined`);
+  }
+
+  return {
+    profileName: requestedProfileName,
+    executionMode: rawProfile.execution_mode,
+    langfuseHost: rawProfile.langfuse_host,
+  };
+}
+
+export function createDefaultLangfuseGateway(options: DefaultLangfuseGatewayOptions): TelemetryGateway {
+  return new TelemetryGateway({
+    buffer: options.buffer ?? new FileBuffer(),
+    sink: options.sink ?? new LangfuseSink({ profile: buildLangfuseProfile(options.profile) }),
+    dispatchMode: options.dispatchMode ?? "fanout",
+  });
+}

--- a/services/telemetry-gateway-composer/src/index.ts
+++ b/services/telemetry-gateway-composer/src/index.ts
@@ -2,4 +2,11 @@ export {
   buildDefaultTelemetryGatewayDependencies,
   createDefaultTelemetryGateway,
 } from "./default_telemetry_gateway.js";
+export { createDefaultLangfuseGateway, resolveLangfuseRuntimeProfile } from "./default_langfuse_gateway.js";
 export type { DefaultTelemetryGatewayOptions } from "./default_telemetry_gateway.js";
+export type {
+  DefaultLangfuseGatewayOptions,
+  LangfuseLocalRuntimeProfile,
+  LangfuseRuntimeProfileCatalog,
+  LangfuseRuntimeProfileSource,
+} from "./default_langfuse_gateway.js";

--- a/sinks/langfuse-sink/src/index.ts
+++ b/sinks/langfuse-sink/src/index.ts
@@ -1,2 +1,3 @@
 export { buildDeliveryOutcome } from "./delivery_policy.js";
 export { LangfuseSink } from "./langfuse_sink.js";
+export type { LangfuseSinkOptions, LangfuseSinkProfile } from "./langfuse_sink.js";

--- a/sinks/langfuse-sink/src/langfuse_sink.ts
+++ b/sinks/langfuse-sink/src/langfuse_sink.ts
@@ -7,8 +7,25 @@ import { normalizeTelemetryEnvelope } from "@rather-not-work-on/telemetry-gatewa
 
 import { buildDeliveryOutcome } from "./delivery_policy.js";
 
+export interface LangfuseSinkProfile {
+  runtimeProfileName: string;
+  host: string;
+  executionMode?: string;
+}
+
+export interface LangfuseSinkOptions {
+  profile?: LangfuseSinkProfile;
+}
+
 export class LangfuseSink implements TelemetrySinkDeliveryPort {
+  constructor(private readonly options: LangfuseSinkOptions = {}) {}
+
   deliver(envelope: TelemetryEnvelope): TelemetrySinkDeliveryOutcome {
-    return buildDeliveryOutcome(normalizeTelemetryEnvelope(envelope));
+    const outcome = buildDeliveryOutcome(normalizeTelemetryEnvelope(envelope));
+
+    return {
+      ...outcome,
+      delivered: outcome.delivered && (!this.options.profile || this.options.profile.host.length > 0),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- add an observability-owned Langfuse local composer that resolves planningops-style runtime profiles
- keep host/profile wiring in the composer and sink layers instead of the telemetry gateway core
- export profile-aware gateway builders for the next local smoke wave

## Scope
- Service/sink/buffer/config/docs: `services/telemetry-gateway-composer`, `sinks/langfuse-sink`
- Scripts/contracts: none
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#228
- Related rather-not-work-on/platform-planningops#230

## Validation
- [x] `npm exec --yes pnpm@9.15.9 -- typecheck`
- [x] `bash scripts/test_module_readmes.sh`
- [x] Additional checks (if any): `PATH="$PWD/.venv.ci/bin:$PATH" bash scripts/test_observability_guardrails.sh`; `npx --yes tsx -e 'import { resolveLangfuseRuntimeProfile, createDefaultLangfuseGateway } from "./services/telemetry-gateway-composer/src/index.ts"; const catalog={active_profile:"local",profiles:{local:{execution_mode:"local",langfuse_host:"http://127.0.0.1:3001"}}}; const profile=resolveLangfuseRuntimeProfile(catalog); const gateway=createDefaultLangfuseGateway({profile}); const outcome=gateway.ingest({envelope:{runId:"r1",missionId:"m1",eventName:"executor.complete"}}); console.log(JSON.stringify({profile,outcome}))'`; `git diff --check`

## Risks
- Risk: the Langfuse-aware sink remains transport-stubbed until wave12 adds the live smoke wrapper, so this wave only proves composition boundaries.
- Rollback: revert this PR to restore the previous default telemetry gateway composition.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [ ] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
