### PR TITLE
feat(observability): add replay reason taxonomy and offline validator fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ python3 scripts/validate_contract_pin.py
 bash scripts/test_observability_guardrails.sh
 ```
 
+Notes:
+- schema validation prefers `jsonschema` when installed and falls back to `scripts/jsonschema_compat.py` in offline environments.
+
 ## Local LangFuse Launcher and Replay/Backfill Drill
 ```bash
 bash scripts/langfuse_stack_launcher.sh --mode dry-run

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ python3 scripts/langfuse_ingest_smoke.py --scenario normal
 python3 scripts/langfuse_ingest_smoke.py --scenario delay_and_replay
 python3 scripts/validate_ingest_smoke_evidence.py \
   --report runtime-artifacts/ingest/<run_id>-delay_and_replay.json
+python3 scripts/validate_delay_replay_reason_taxonomy_map.py
 python3 scripts/validate_contract_pin.py
 bash scripts/test_observability_guardrails.sh
 ```
@@ -72,12 +73,14 @@ Artifacts:
 - checks:
   - ingest smoke (`normal`, `delay_and_replay`)
   - ingest smoke evidence validation (`scripts/validate_ingest_smoke_evidence.py`)
+  - delay/replay reason taxonomy map validation (`scripts/validate_delay_replay_reason_taxonomy_map.py`)
   - deterministic replay/dedupe assertions
   - contract pin validation (`scripts/validate_contract_pin.py`)
   - seeded failure guard (`scripts/test_observability_guardrails.sh`)
   - topology/module README regression (`scripts/test_module_readmes.sh`)
 - evidence contract: `contracts/c5-observability-ingest-smoke-artifact.schema.json`
 - reason taxonomy: `config/observability-reason-taxonomy.json`
+- reason map: `config/delay-replay-reason-taxonomy-map.json`
 - runbook: `docs/runbook/ingest-smoke-evidence-runbook.md`
 
 ### Contract Pin Remediation

--- a/config/README.md
+++ b/config/README.md
@@ -6,6 +6,7 @@ Store static observability-gateway configuration and examples.
 ## Contents
 - contract pin metadata
 - observability reason taxonomy
+- delay/replay reason taxonomy map
 - ingest/replay policy examples
 
 ## Rules

--- a/config/delay-replay-reason-taxonomy-map.json
+++ b/config/delay-replay-reason-taxonomy-map.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "taxonomy_source": "config/observability-reason-taxonomy.json",
+  "taxonomy_version": 1,
+  "reason_code_map": {
+    "ok": {
+      "severity": "info",
+      "retryable": false,
+      "operator_action": "none"
+    },
+    "replay_recovered": {
+      "severity": "warn",
+      "retryable": true,
+      "operator_action": "monitor_replay_latency"
+    },
+    "missing_required_fields": {
+      "severity": "error",
+      "retryable": false,
+      "operator_action": "fix_event_payload_contract"
+    },
+    "continuity_error": {
+      "severity": "error",
+      "retryable": true,
+      "operator_action": "investigate_replay_sequence"
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ Host repeatable local ingest/replay smoke, validation, and launcher tooling.
 - ingest smoke scenarios
 - launcher-backed live smoke wrapper
 - evidence validators
+- delay/replay reason taxonomy map validator
 - contract pin validation
 - stack launcher helpers
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ Host repeatable local ingest/replay smoke, validation, and launcher tooling.
 - ingest smoke scenarios
 - launcher-backed live smoke wrapper
 - evidence validators
+- jsonschema compatibility fallback
 - delay/replay reason taxonomy map validator
 - contract pin validation
 - stack launcher helpers

--- a/scripts/jsonschema_compat.py
+++ b/scripts/jsonschema_compat.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, List, Sequence
+
+
+@dataclass
+class ValidationError(Exception):
+    absolute_path: Sequence[Any]
+    message: str
+    validator: str
+
+    @property
+    def path(self) -> Sequence[Any]:
+        return self.absolute_path
+
+
+class SchemaError(Exception):
+    pass
+
+
+class FormatChecker:
+    def __init__(self):
+        self.checkers = {"date-time": self._check_datetime}
+
+    def conforms(self, value: Any, fmt: str) -> bool:
+        checker = self.checkers.get(fmt)
+        if checker is None:
+            return True
+        return checker(value)
+
+    @staticmethod
+    def _check_datetime(value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        probe = value.replace("Z", "+00:00")
+        try:
+            datetime.fromisoformat(probe)
+            return True
+        except ValueError:
+            return False
+
+
+class _FallbackDraft202012Validator:
+    def __init__(self, schema: dict, format_checker: FormatChecker | None = None):
+        self.schema = schema
+        self.format_checker = format_checker or FormatChecker()
+
+    @staticmethod
+    def check_schema(schema: dict):
+        if not isinstance(schema, dict):
+            raise SchemaError("schema must be an object")
+        if schema.get("type") != "object":
+            raise SchemaError("only object-root schemas are supported by local fallback")
+
+    def validate(self, instance: Any):
+        errors = list(self.iter_errors(instance))
+        if errors:
+            first = errors[0]
+            raise ValidationError(first.absolute_path, first.message, first.validator)
+
+    def iter_errors(self, instance: Any) -> Iterable[ValidationError]:
+        yield from _iter_schema_errors(self.schema, instance, [], self.format_checker)
+
+
+def _iter_schema_errors(
+    schema: dict, value: Any, path: List[Any], format_checker: FormatChecker
+) -> Iterable[ValidationError]:
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        if expected_type == "object" and not isinstance(value, dict):
+            yield ValidationError(list(path), "is not of type 'object'", "type")
+            return
+        if expected_type == "string" and not isinstance(value, str):
+            yield ValidationError(list(path), "is not of type 'string'", "type")
+            return
+        if expected_type == "integer" and not isinstance(value, int):
+            yield ValidationError(list(path), "is not of type 'integer'", "type")
+            return
+        if expected_type == "array" and not isinstance(value, list):
+            yield ValidationError(list(path), "is not of type 'array'", "type")
+            return
+
+    if "const" in schema and value != schema["const"]:
+        yield ValidationError(list(path), f"{value!r} is not equal to const", "const")
+
+    if "enum" in schema and value not in schema["enum"]:
+        yield ValidationError(list(path), f"{value!r} is not one of {schema['enum']}", "enum")
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if min_length is not None and len(value) < min_length:
+            yield ValidationError(list(path), f"is too short (minLength={min_length})", "minLength")
+        pattern = schema.get("pattern")
+        if pattern is not None and re.search(pattern, value) is None:
+            yield ValidationError(list(path), f"{value!r} does not match {pattern!r}", "pattern")
+        fmt = schema.get("format")
+        if fmt is not None and not format_checker.conforms(value, fmt):
+            yield ValidationError(list(path), f"{value!r} is not a '{fmt}'", "format")
+
+    if isinstance(value, int):
+        minimum = schema.get("minimum")
+        if minimum is not None and value < minimum:
+            yield ValidationError(list(path), f"{value} is less than minimum {minimum}", "minimum")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in value:
+                yield ValidationError(list(path), f"{key!r} is a required property", "required")
+
+        min_props = schema.get("minProperties")
+        if min_props is not None and len(value) < min_props:
+            yield ValidationError(
+                list(path),
+                f"{len(value)} properties found, minimum is {min_props}",
+                "minProperties",
+            )
+
+        properties = schema.get("properties", {})
+        additional = schema.get("additionalProperties", True)
+        for key, item in value.items():
+            child_path = [*path, key]
+            if key in properties:
+                yield from _iter_schema_errors(properties[key], item, child_path, format_checker)
+            elif additional is False:
+                yield ValidationError(child_path, f"additional property {key!r} is not allowed", "additionalProperties")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            yield ValidationError(
+                list(path),
+                f"{len(value)} items found, minimum is {min_items}",
+                "minItems",
+            )
+        item_schema = schema.get("items")
+        if item_schema:
+            for idx, item in enumerate(value):
+                yield from _iter_schema_errors(item_schema, item, [*path, idx], format_checker)
+
+
+def _build_fallback_exports():
+    return _FallbackDraft202012Validator, FormatChecker, SchemaError
+
+
+def load_validator_exports():
+    force_local = os.getenv("UAP_FORCE_LOCAL_JSONSCHEMA", "").lower() in {"1", "true", "yes"}
+    if not force_local:
+        try:
+            from jsonschema import Draft202012Validator, FormatChecker as JsonschemaFormatChecker
+            from jsonschema.exceptions import SchemaError as JsonschemaSchemaError
+
+            return Draft202012Validator, JsonschemaFormatChecker, JsonschemaSchemaError
+        except ImportError:
+            pass
+    return _build_fallback_exports()

--- a/scripts/observability_smoke_contract.py
+++ b/scripts/observability_smoke_contract.py
@@ -3,7 +3,9 @@
 import json
 from pathlib import Path
 
-from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema_compat import load_validator_exports
+
+Draft202012Validator, FormatChecker, _ = load_validator_exports()
 
 
 def load_json(path: Path):

--- a/scripts/test_observability_guardrails.sh
+++ b/scripts/test_observability_guardrails.sh
@@ -25,6 +25,9 @@ python3 "$ROOT_DIR/scripts/validate_ingest_smoke_evidence.py" \
   --report "$OUT_DIR/$RUN_ID-delay_and_replay.json" \
   --output "$TMP_DIR/o11y-replay-validation.json"
 
+python3 "$ROOT_DIR/scripts/validate_delay_replay_reason_taxonomy_map.py" \
+  --output "$TMP_DIR/delay-replay-reason-taxonomy-map-report.json"
+
 NORMAL_REPORT="$OUT_DIR/$RUN_ID-normal.json"
 REPLAY_REPORT="$OUT_DIR/$RUN_ID-delay_and_replay.json"
 

--- a/scripts/validate_delay_replay_reason_taxonomy_map.py
+++ b/scripts/validate_delay_replay_reason_taxonomy_map.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+ALLOWED_SEVERITY = {"info", "warn", "error"}
+ALLOWED_ACTION = {
+    "none",
+    "monitor_replay_latency",
+    "fix_event_payload_contract",
+    "investigate_replay_sequence",
+}
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def validate_map_doc(map_doc: dict, taxonomy_doc: dict):
+    errors = []
+
+    taxonomy_codes = taxonomy_doc.get("reason_codes") if isinstance(taxonomy_doc, dict) else {}
+    map_codes = map_doc.get("reason_code_map") if isinstance(map_doc, dict) else {}
+
+    if not isinstance(taxonomy_codes, dict) or not taxonomy_codes:
+        errors.append("taxonomy reason_codes must be a non-empty object")
+        taxonomy_codes = {}
+    if not isinstance(map_codes, dict) or not map_codes:
+        errors.append("reason_code_map must be a non-empty object")
+        map_codes = {}
+
+    if map_doc.get("taxonomy_source") != "config/observability-reason-taxonomy.json":
+        errors.append("taxonomy_source must be config/observability-reason-taxonomy.json")
+
+    if map_doc.get("taxonomy_version") != taxonomy_doc.get("version"):
+        errors.append(
+            f"taxonomy_version mismatch: map={map_doc.get('taxonomy_version')} taxonomy={taxonomy_doc.get('version')}"
+        )
+
+    missing_codes = sorted(set(taxonomy_codes) - set(map_codes))
+    extra_codes = sorted(set(map_codes) - set(taxonomy_codes))
+    if missing_codes:
+        errors.append(f"missing reason_code_map entries={missing_codes}")
+    if extra_codes:
+        errors.append(f"unknown reason_code_map entries={extra_codes}")
+
+    for code, row in map_codes.items():
+        if not isinstance(row, dict):
+            errors.append(f"reason_code_map[{code}] must be an object")
+            continue
+
+        severity = row.get("severity")
+        if severity not in ALLOWED_SEVERITY:
+            errors.append(f"reason_code_map[{code}].severity invalid: {severity}")
+
+        retryable = row.get("retryable")
+        if not isinstance(retryable, bool):
+            errors.append(f"reason_code_map[{code}].retryable must be boolean")
+
+        action = row.get("operator_action")
+        if action not in ALLOWED_ACTION:
+            errors.append(f"reason_code_map[{code}].operator_action invalid: {action}")
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate delay/replay reason taxonomy map")
+    parser.add_argument("--map", default="config/delay-replay-reason-taxonomy-map.json")
+    parser.add_argument("--taxonomy", default="config/observability-reason-taxonomy.json")
+    parser.add_argument(
+        "--output", default="runtime-artifacts/validation/delay-replay-reason-taxonomy-map-report.json"
+    )
+    args = parser.parse_args()
+
+    map_path = Path(args.map)
+    taxonomy_path = Path(args.taxonomy)
+
+    map_doc = load_json(map_path)
+    taxonomy_doc = load_json(taxonomy_path)
+
+    errors = validate_map_doc(map_doc, taxonomy_doc)
+    verdict = "pass" if not errors else "fail"
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "verdict": verdict,
+        "map_path": args.map,
+        "taxonomy_path": args.taxonomy,
+        "error_count": len(errors),
+        "errors": errors,
+    }
+    save_json(Path(args.output), report)
+
+    print(f"report written: {args.output}")
+    print(f"verdict={verdict} error_count={len(errors)}")
+    return 0 if verdict == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add delay/replay reason taxonomy validation for observability smoke outcomes
- add offline JSON Schema fallback for ingest smoke evidence validation
- keep observability guardrails green in offline/local environments

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: none
- `.github/` workflows: none

## Linked Issues
- Closes #
- Related #3
- Related rather-not-work-on/platform-planningops#109

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 scripts/validate_delay_replay_reason_taxonomy_map.py`; `bash scripts/test_observability_guardrails.sh`; `./node_modules/.bin/tsc --noEmit -p tsconfig.base.json`

## Risks
- Risk: fallback validator must stay in sync with ingest schema evolution and replay evidence semantics.
- Rollback: revert commits `e68faad` and `53ab5c1` on `main`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
